### PR TITLE
Misc bug fixes and improvements

### DIFF
--- a/evohome_
+++ b/evohome_
@@ -87,11 +87,7 @@ class EvohomeMuninPlugin(MuninPlugin):
     # if the file is not older than 5 minutes we don't need to fetch the data
     def write_zone_info(self):
 
-        # Read or construct data persitent data
-        try:
-            data = json.load(io.open(self.PERSISTENT_STORAGE, "rb"))
-        except:
-            data = []
+        data = []
 
         try:
             stat = os.stat(self.PERSISTENT_STORAGE)
@@ -117,10 +113,6 @@ class EvohomeMuninPlugin(MuninPlugin):
     # write weather data to JSON file
     # if the file is not older than 15 minutes we don't need to fetch the data
     def write_weather_info(self):
-        try:
-            data = json.load(io.open(self.WEATHER_DATA, "rb"))
-        except:
-            data = []
 
         try:
             stat = os.stat(self.WEATHER_DATA)

--- a/evohome_
+++ b/evohome_
@@ -101,7 +101,12 @@ class EvohomeMuninPlugin(MuninPlugin):
             age_minutes = (time.time() - stat.st_mtime) / 60
                 
         if age_minutes >= 5:
-            client = EvohomeClient(self.username, self.password)
+            try:
+                client = EvohomeClient(self.username, self.password)
+            except:
+                sys.stderr.write('Connection to the server failed or server returned an error.\n')
+                sys.exit(1)
+
             for device in client.temperatures():
                 data.append(device)
 

--- a/evohome_
+++ b/evohome_
@@ -56,11 +56,14 @@ class EvohomeMuninPlugin(MuninPlugin):
             label="Temperature",
             info="Temperature in Room",
             type="GAUGE",
+            max="50"
         )),
         ('setpoint', dict(
             label="Temperature SP",
             info="Temperature Setpoint in Room",
             type="GAUGE",
+            max="35",
+            min="5"
         )),
         ('outside_temperature', dict(
             label="Outside Temperature",

--- a/evohome_
+++ b/evohome_
@@ -84,7 +84,7 @@ class EvohomeMuninPlugin(MuninPlugin):
         self.zonename = (sys.argv[0].split('_', 1)[-1].replace('_',' ')
                 if self.zonename_in_args else None)
     # write zone info to JSON file
-    # if the file is not older than 5 minutes we don't need to fetch the data
+    # if the file is not older than 4 minutes we don't need to fetch the data
     def write_zone_info(self):
 
         data = []
@@ -96,7 +96,7 @@ class EvohomeMuninPlugin(MuninPlugin):
         else:
             age_minutes = (time.time() - stat.st_mtime) / 60
                 
-        if age_minutes >= 5:
+        if age_minutes > 4:
             try:
                 client = EvohomeClient(self.username, self.password)
             except:
@@ -111,7 +111,7 @@ class EvohomeMuninPlugin(MuninPlugin):
             f.close()
 
     # write weather data to JSON file
-    # if the file is not older than 15 minutes we don't need to fetch the data
+    # if the file is not older than 14 minutes we don't need to fetch the data
     def write_weather_info(self):
 
         try:
@@ -121,7 +121,7 @@ class EvohomeMuninPlugin(MuninPlugin):
         else:
             age_minutes = (time.time() - stat.st_mtime) / 60
                 
-        if age_minutes >= 15:
+        if age_minutes > 14:
             weather_com_result = pywapi.get_weather_from_weather_com(self.location,  units = 'metric' ) 
             weather = dict()
 

--- a/evohome_
+++ b/evohome_
@@ -20,7 +20,7 @@
     To activate the plugin make a symlink
     #ln -s /usr/local/share/munin/plugins/evohome_ /usr/local/etc/munin/plugins/evohome_Zonename
     
-    For the moment the zonenames should not contain spaces
+    For zone names containing spaces, replace the spaces with underscores in the symlink name
 """
 
 

--- a/evohome_
+++ b/evohome_
@@ -73,7 +73,7 @@ class EvohomeMuninPlugin(MuninPlugin):
     )
 
     zonename_in_args = True
-    category = "domotic"
+    category = "evohome"
 
     # This is the file which has the zone data
     PERSISTENT_STORAGE = "/tmp/munin-zone-data.json"

--- a/evohome_
+++ b/evohome_
@@ -33,7 +33,7 @@ import io
 from pprint import pprint
 import pywapi
 from munin import MuninPlugin
-from evohomeclient2 import EvohomeClient
+from evohomeclient import EvohomeClient
 
 
 class EvohomeMuninPlugin(MuninPlugin):
@@ -98,7 +98,7 @@ class EvohomeMuninPlugin(MuninPlugin):
             age_minutes = (time.time() - stat.st_mtime) / 60
                 
         if age_minutes >= 5:
-            client = EvohomeClient(self.username, self.password, debug=False)
+            client = EvohomeClient(self.username, self.password)
             for device in client.temperatures():
                 data.append(device)
 


### PR DESCRIPTION
I've broken a number of fixes and improvements out into separate commits.

The Honeywell V2 API has a high failure rate for me of over 20%, (HTTP 500 server errors at random) which would just crash the script and leave gaps in the graph. I first experimented with automatic delayed retries but even with 2 additional retries I still saw the occasional gap in the graph, and don't like the idea of retries contributing to further server congestion.

The V1 API also provides the data that this script needs and seems to do so without a single failed connection attempt over 24 hours...

I wasn't really sure looking at the code why you were appending the json data from each server query to the last, this just leads to the file growing forever, and the data for every zone is returned for every server query, so we only need to cache the last 4/5 minutes results.

The first zone plugin run in each plugin processing interval will invalidate the cache and overwrite it with newly obtained data, all the following zones run in the same interval will read their data from the cache, then in the next 5 minute (or later) interval the cache will be replaced again.

The unknown temperature spike was an interesting one - I reset the evotouch controller (resulting in an hour glass for one zone) next thing I have a huge spike in my graph that auto-scaled the rest of the data into oblivion :) Turns out Honeywell send 128.0 as the zone temperature when the temperature is "unknown". With the max limit applied it will now just leave a gap in the graph for only the measured temperature when it is unknown.

Hope you like the changes.
