### PR TITLE
If the zone name is not found exit with an appropriate exit code and …

### DIFF
--- a/evohome_
+++ b/evohome_
@@ -157,9 +157,10 @@ class EvohomeMuninPlugin(MuninPlugin):
             if i['name'] == self.zonename:
                 temperature = i['temp']
                 setpoint = i['setpoint']
+                return temperature, setpoint,outside_temperature
 
-        return temperature, setpoint,outside_temperature
-
+        sys.stderr.write('Zone ' + self.zonename + ' not found. Please check the zone exists and is named correctly.\n')
+        sys.exit(1)
 
     @property
     def title(self):


### PR DESCRIPTION
…error message (for the munin-node.log) instead of crashing.
